### PR TITLE
add macro to explicit depend on kernel builddep packages

### DIFF
--- a/ec_sys-kmod.spec
+++ b/ec_sys-kmod.spec
@@ -30,6 +30,8 @@ BuildRequires:  kernel-devel
 BuildRequires:  koji
 BuildRequires:  rustfmt
 BuildRequires:  %{_bindir}/kmodtool
+BuildRequires:  kernel-rpm-macros
+BuildRequires:  %{?kernel_module_package_buildreqs}
 
 %{!?kernels:BuildRequires: buildsys-build-rpmfusion-kerneldevpkgs-%{?buildforkernels:%{buildforkernels}}%{!?buildforkernels:current}-%{_target_cpu} }
 


### PR DESCRIPTION
This should fix the problem when installing the akmod version of this module.

The kernel build dependencies were missing.

Closes #3 