### PR TITLE
Fixes for Ultramarine Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ This project is licensed under the **MIT** and **GPLv2** licenses. See the `LICE
 ## Maintainer
 - [**Federico Manzella**](https://github.com/ferdiu)
 
+## Contributors
+- [**Kris**](https://github.com/kris3713): add support for Ultramarine Linux (and potentially any other Fedora-based distros)
+
 ## Changelog
 ### v1.0 (Feb 12, 2025)
 - Initial release

--- a/ec_sys-kmod.spec
+++ b/ec_sys-kmod.spec
@@ -63,6 +63,7 @@ for kernel_version in %{?kernel_versions} ; do
     kernel_v=${kernel_version%%___*}                            # eg. 6.12.11-200.fc41.x86_64
     kernel_v_no_arch=${kernel_v%.*}                             # eg. 6.12.11-200.fc41
     kernel_extra=${kernel_v#*-}                                 # eg. 200.fc41.x86_64
+    kernel_patch=${kernel_extra%%%%.*}                          # eg. 200
     kernel_v_no_extra="$(echo -n ${kernel_v} | cut -d"-" -f1)"  # eg. 6.12.11
     kernel_src_dir=${kernel_version##*__}                       # eg. /usr/src/kernels/6.12.11-200.fc41.x86_64
 
@@ -96,7 +97,7 @@ for kernel_version in %{?kernel_versions} ; do
         -bp --target="$(uname -m)" kernel.spec 2>&1 || true # Even if it fail we are ok!
 
     if [ %{fedora} -gt 40 ]; then
-        build_dir="./kernel-${kernel_v_no_extra}-build/kernel-${kernel_v_no_extra}/linux-${kernel_v}"
+        build_dir="./kernel-${kernel_v_no_extra}-build/kernel-${kernel_v_no_extra}/linux-${kernel_v_no_extra}-${kernel_patch}%{dist}.%{_arch}"
     else
         build_dir="./kernel-${kernel_v_no_extra}/linux-${kernel_v}"
     fi

--- a/ec_sys-kmod.spec
+++ b/ec_sys-kmod.spec
@@ -65,7 +65,8 @@ for the EC_SYS ACPI debugging (and writing).
 kmodtool --target %{_target_cpu} \
     --repo %{repo} \
     --kmodname %{name} \
-    %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null | \
+    %{?buildforkernels:--%{buildforkernels}} \
+    %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null | \
         sed 's|extra|updates|g' | \
             sed 's|%{kmod_name}/||g'
 


### PR DESCRIPTION
This PR adds patches for Ultramarine Linux to ensure compiling the **`ec_sys`** module will be possible on there.

Additionally, I also refactored the commands for the `kmodtool` to make them more human-readable.